### PR TITLE
Setup database and Prisma ORM

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,22 @@
+// Whenever you need access to the database, you can import the prisma
+// instance into the file where it's needed.
+
+import { PrismaClient } from "@prisma/client";
+
+let prisma: PrismaClient;
+
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient();
+} else {
+  const globalWithPrisma = global as typeof globalThis & {
+    prisma: PrismaClient;
+  };
+
+  if (!globalWithPrisma.prisma) {
+    globalWithPrisma.prisma = new PrismaClient();
+  }
+
+  prisma = globalWithPrisma.prisma;
+}
+
+export default prisma;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource/inter": "^5.0.16",
+        "@prisma/client": "^5.10.2",
         "classnames": "^2.5.1",
         "next": "14.1.0",
         "normalize.css": "^8.0.1",
@@ -42,6 +43,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
+        "prisma": "^5.10.2",
         "sass": "^1.71.1",
         "storybook": "^7.6.17",
         "stylelint": "^16.2.1",
@@ -4009,6 +4011,68 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.10.2.tgz",
+      "integrity": "sha512-ef49hzB2yJZCvM5gFHMxSFL9KYrIP9udpT5rYo0CsHD4P9IKj473MbhU1gjKKftiwWBTIyrt9jukprzZXazyag==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.10.2.tgz",
+      "integrity": "sha512-bkBOmH9dpEBbMKFJj8V+Zp8IZHIBjy3fSyhLhxj4FmKGb/UBSt9doyfA6k1UeUREsMJft7xgPYBbHSOYBr8XCA==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.10.2.tgz",
+      "integrity": "sha512-HkSJvix6PW8YqEEt3zHfCYYJY69CXsNdhU+wna+4Y7EZ+AwzeupMnUThmvaDA7uqswiHkgm5/SZ6/4CStjaGmw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/debug": "5.10.2",
+        "@prisma/engines-version": "5.10.0-34.5a9203d0590c951969e85a7d07215503f4672eb9",
+        "@prisma/fetch-engine": "5.10.2",
+        "@prisma/get-platform": "5.10.2"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.10.0-34.5a9203d0590c951969e85a7d07215503f4672eb9",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.10.0-34.5a9203d0590c951969e85a7d07215503f4672eb9.tgz",
+      "integrity": "sha512-uCy/++3Jx/O3ufM+qv2H1L4tOemTNqcP/gyEVOlZqTpBvYJUe0tWtW0y3o2Ueq04mll4aM5X3f6ugQftOSLdFQ==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.10.2.tgz",
+      "integrity": "sha512-dSmXcqSt6DpTmMaLQ9K8ZKzVAMH3qwGCmYEZr/uVnzVhxRJ1EbT/w2MMwIdBNq1zT69Rvh0h75WMIi0mrIw7Hg==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.10.2",
+        "@prisma/engines-version": "5.10.0-34.5a9203d0590c951969e85a7d07215503f4672eb9",
+        "@prisma/get-platform": "5.10.2"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.10.2.tgz",
+      "integrity": "sha512-nqXP6vHiY2PIsebBAuDeWiUYg8h8mfjBckHh6Jezuwej0QJNnjDiOq30uesmg+JXxGk99nqyG3B7wpcOODzXvg==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.10.2"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -18939,6 +19003,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.10.2.tgz",
+      "integrity": "sha512-hqb/JMz9/kymRE25pMWCxkdyhbnIWrq+h7S6WysJpdnCvhstbJSNP/S6mScEcqiB8Qv2F+0R3yG+osRaWqZacQ==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "5.10.2"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.0.16",
+    "@prisma/client": "^5.10.2",
     "classnames": "^2.5.1",
     "next": "14.1.0",
     "normalize.css": "^8.0.1",
@@ -53,6 +54,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
+    "prisma": "^5.10.2",
     "sass": "^1.71.1",
     "storybook": "^7.6.17",
     "stylelint": "^16.2.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,29 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("POSTGRES_PRISMA_URL") // uses connection pooling
+  directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
+}
+
+// model Post {
+//   id        String  @id @default(cuid())
+//   title     String
+//   content   String?
+//   published Boolean @default(false)
+//   author    User?   @relation(fields: [authorId], references: [id])
+//   authorId  String?
+// }
+
+model User {
+  id        String   @id @default(cuid())
+  name      String?
+  email     String?  @unique
+  createdAt DateTime @default(now()) @map(name: "created_at")
+  updatedAt DateTime @updatedAt @map(name: "updated_at")
+  // posts     Post[]
+
+  @@map(name: "users")
+}


### PR DESCRIPTION
## What?
I installed and set up Prisma as an ORM to integrate with the Vercel PostgreSQL database.

## Why?
Prisma allows for easier programmatic access to database CRUD operations.

## How?
I installed Prisma and Prisma Client dependencies. I created an initial database schema file and configured Prisma Client to be imported into files where it is needed to access the database.