### PR TITLE
 Add Text Input UI kit component

### DIFF
--- a/features/ui/button/button.stories.tsx
+++ b/features/ui/button/button.stories.tsx
@@ -17,24 +17,6 @@ export const Default: Story = {
       options: Object.values(ButtonColor),
     },
   },
-  parameters: {
-    controls: {
-      exclude: [
-        "form",
-        "formAction",
-        "formEncType",
-        "formMethod",
-        "formNoValidate",
-        "formTarget",
-        "name",
-        "value",
-        "autoFocus",
-        "type",
-        "className",
-        "style",
-      ],
-    },
-  },
 };
 
 export const Small: Story = {

--- a/features/ui/button/button.tsx
+++ b/features/ui/button/button.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import {
-  Button as AriaButton,
-  ButtonRenderProps as AriaButtonRenderProps,
-} from "react-aria-components";
+import type { ButtonProps as AriaButtonProps } from "react-aria-components";
+import { Button as AriaButton } from "react-aria-components";
 import classNames from "classnames";
 import styles from "./button.module.scss";
 
@@ -28,27 +26,6 @@ export enum ButtonVariant {
 // React-Aria Button component is not native HTML Button element,
 // so doesn't make sense to extend it.
 // https://react-spectrum.adobe.com/react-aria/Button.html#props
-type AriaButtonProps = {
-  form?: string;
-  formAction?: string;
-  formEncType?: string;
-  formMethod?: string;
-  formNoValidate?: boolean;
-  formTarget?: string;
-  name?: string;
-  value?: string;
-  isDisabled?: boolean;
-  autoFocus?: boolean;
-  type?: "button" | "submit" | "reset";
-  children?:
-    | React.ReactNode
-    | ((values: AriaButtonRenderProps) => React.ReactNode);
-  className?: string | ((values: AriaButtonRenderProps) => string);
-  style?:
-    | React.CSSProperties
-    | ((values: AriaButtonRenderProps) => React.CSSProperties);
-};
-
 type ButtonProps = AriaButtonProps & {
   size?: ButtonSize;
   color?: ButtonColor;

--- a/features/ui/index.ts
+++ b/features/ui/index.ts
@@ -1,2 +1,3 @@
 // Barrel file
 export * from "./button";
+export * from "./text-input";

--- a/features/ui/text-input/index.ts
+++ b/features/ui/text-input/index.ts
@@ -1,0 +1,1 @@
+export { TextInput } from "./text-input";

--- a/features/ui/text-input/text-input.module.scss
+++ b/features/ui/text-input/text-input.module.scss
@@ -11,3 +11,39 @@
   color: color.$general-80;
   font: font.$text-sm-medium;
 }
+
+.input {
+  height: 2.5rem;
+  padding: 0.625rem 0.875rem;
+  gap: space.$s2;
+  border-radius: 0.25rem;
+  border: 1px solid color.$form-gray-50;
+  background: color.$white;
+  box-sizing: border-box;
+  cursor: text;
+  color: color.$general-90;
+  font: font.$text-md-regular;
+  outline: none;
+
+  &::placeholder {
+    color: color.$general-60;
+  }
+
+  &:focus-within {
+    border-color: color.$primary-80;
+  }
+
+  &:disabled {
+    color: color.$general-80;
+    background: color.$form-disabled;
+    cursor: not-allowed;
+  }
+
+  &[data-invalid] {
+    border-color: color.$red-80;
+  }
+}
+
+.field-error {
+  color: color.$red-80;
+}

--- a/features/ui/text-input/text-input.module.scss
+++ b/features/ui/text-input/text-input.module.scss
@@ -1,0 +1,13 @@
+@use "@styles/color";
+@use "@styles/font";
+
+// @use "@styles/shadow";
+@use "@styles/space";
+
+.text-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  color: color.$general-80;
+  font: font.$text-sm-medium;
+}

--- a/features/ui/text-input/text-input.stories.tsx
+++ b/features/ui/text-input/text-input.stories.tsx
@@ -1,0 +1,44 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { TextInput } from ".";
+
+// Storybook CSF3 format
+
+const meta: Meta<typeof TextInput> = {
+  title: "UI/TextInput",
+  component: TextInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof TextInput>;
+
+// Default is uncontrolled component
+export const Default: Story = {
+  args: {
+    isDisabled: false,
+  },
+};
+
+export const Label: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    label: "Label",
+  },
+};
+
+export const Hint: Story = {
+  ...Label,
+  args: {
+    ...Label.args,
+    description: "This is a description to inform the user.",
+  },
+};
+
+export const Error: Story = {
+  ...Hint,
+  args: {
+    ...Hint.args,
+    isInvalid: true,
+    errorMessage: "This is an error message.",
+  },
+};

--- a/features/ui/text-input/text-input.stories.tsx
+++ b/features/ui/text-input/text-input.stories.tsx
@@ -15,6 +15,7 @@ type Story = StoryObj<typeof TextInput>;
 export const Default: Story = {
   args: {
     isDisabled: false,
+    placeholder: "Search",
   },
 };
 

--- a/features/ui/text-input/text-input.tsx
+++ b/features/ui/text-input/text-input.tsx
@@ -18,6 +18,7 @@ type TextInputProps = TextFieldProps & {
   description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
   icon?: React.ReactNode;
+  placeholder?: string;
 };
 
 export function TextInput({
@@ -25,6 +26,7 @@ export function TextInput({
   className,
   description,
   errorMessage,
+  placeholder,
   ...props
 }: TextInputProps) {
   return (
@@ -33,9 +35,13 @@ export function TextInput({
       {...props}
     >
       {label && <Label>{label}</Label>}
-      <Input />
+      <Input className={styles.input} placeholder={placeholder} />
       {description && <Text slot="description">{description}</Text>}
-      {errorMessage && <FieldError>{errorMessage}</FieldError>}
+      {errorMessage && (
+        <FieldError className={styles["field-error"]}>
+          {errorMessage}
+        </FieldError>
+      )}
     </TextField>
   );
 }

--- a/features/ui/text-input/text-input.tsx
+++ b/features/ui/text-input/text-input.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import type { TextFieldProps, ValidationResult } from "react-aria-components";
+import {
+  TextField,
+  Label,
+  Input,
+  FieldError,
+  Text,
+} from "react-aria-components";
+import classNames from "classnames";
+import styles from "./text-input.module.scss";
+
+// Using React Aria Text Field
+// https://react-spectrum.adobe.com/react-aria/TextField.html
+type TextInputProps = TextFieldProps & {
+  label?: string;
+  className?: string;
+  description?: string;
+  errorMessage?: string | ((validation: ValidationResult) => string);
+  icon?: React.ReactNode;
+};
+
+export function TextInput({
+  label,
+  className,
+  description,
+  errorMessage,
+  ...props
+}: TextInputProps) {
+  return (
+    <TextField
+      className={classNames(styles["text-field"], className)}
+      {...props}
+    >
+      {label && <Label>{label}</Label>}
+      <Input />
+      {description && <Text slot="description">{description}</Text>}
+      {errorMessage && <FieldError>{errorMessage}</FieldError>}
+    </TextField>
+  );
+}

--- a/styles/color.scss
+++ b/styles/color.scss
@@ -4,6 +4,10 @@ $white: #fff;
 /* Black */
 $black: #000;
 
+/* Other */
+$form-gray-50: #d9e1ec;
+$form-disabled: #f1f4fa;
+
 /* General */
 $general-100: #131523;
 $general-90: #333752;


### PR DESCRIPTION
## What?
I implemented the text input component for the UI kit based on the Figma design for the project. I added styling and support for validation, labels, and descriptions. In addition, I refactored the Button component to match the prop implementation style of the text input.

## Why?
The text input is necessary for forms and authentication, which is an upcoming task for the project.

## How?
I used the [React Aria](https://react-spectrum.adobe.com/react-aria/TextField.html) text field as a base and built the necessary functionality around it (as specified in the the Figma design). Features such as multiple size variants and inline icons were left out since they may not be necessary.